### PR TITLE
Feature/treat spec ortho

### DIFF
--- a/GridPolator/grid.py
+++ b/GridPolator/grid.py
@@ -1,14 +1,16 @@
-
+from collections import OrderedDict
 import numpy as np
 from jax import numpy as jnp
 from jax import jit
 from jax.scipy.interpolate import RegularGridInterpolator
 from astropy import units as u
 from tqdm.auto import tqdm
+from typing import Tuple, List, OrderedDict
 
 from GridPolator.builtins.phoenix_vspec import read_phoenix
 from GridPolator.astropy_units import isclose
 from GridPolator import config
+from GridPolator.binning import bin_spectra
 
 
 class GridSpectra:
@@ -42,13 +44,70 @@ class GridSpectra:
     >>> GridSpectra(wl,spectra,*params)
 
     """
+    
+    def __init__(
+        self,
+        native_wl: jnp.ndarray,
+        params: OrderedDict[str,jnp.ndarray],
+        spectra: jnp.ndarray
+    ):
+        """
+        Initialize a grid object.
+        
+        Parameters
+        ----------
+        native_wl : jax.numpy.ndarray
+            The native wavelength axis of the grid.
+        params : OrderedDict
+            The other axes of the grid. The order is the same
+            as the order of axes in `spectra`.
+        spectra : jax.numpy.ndarray
+            The flux values to place in the grid. The last dimension
+            should be wavelength.
+        """
+        for param_name, param_val in params.items():
+            if not isinstance(param_name,str):
+                raise TypeError(f'param_name must be a string, but has type {type(param_name)}.')
+            if not isinstance(param_val,jnp.ndarray):
+                raise TypeError(f'param_val must be a jax.numpy.ndarray, but has type {type(param_val)}.')
+            if param_val.ndim != 1:
+                raise ValueError(f'param_val must be 1D, but has shape {param_val.shape}.')
+        n_params = len(params)
+        if spectra.ndim != n_params + 1:
+            raise ValueError(f'spectra must have {n_params} dimensions, but has {spectra.ndim}.')
+        for i, (param_name, param_val) in enumerate(params.items()):
+            if spectra.shape[i] != len(param_val):
+                raise ValueError(f'spectra must have {len(param_val)} values in the {i}th dimension, but has {spectra.shape[i]}.')
+        if native_wl.ndim != 1:
+            raise ValueError(f'native_wl must be a 1D array, but has shape {native_wl.shape}.')
+        wl_len = native_wl.shape[0]
+        if spectra.shape[-1] != wl_len:
+            raise ValueError(f'spectra must have {native_wl.shape[0]} values in the last dimension, but has {spectra.shape[-1]}.')
+        
+        param_tup = tuple(params.values())
+        interp = [RegularGridInterpolator(param_tup,spectra[...,i]) for i in range(wl_len)]
+        
+        self._wl = native_wl
+        self._interp = interp
+        self._params = params
+    @staticmethod
+    def _evaluate(
+        interp: List[RegularGridInterpolator],
+        params: Tuple[jnp.ndarray],
+        wl_native: jnp.ndarray,
+        wl:jnp.ndarray
+    ):
+        result = jnp.array([_interp(params) for _interp in interp])
+        if result.ndim != 2:
+            raise ValueError(f'result must have 2 dimensions, but has {result.ndim}.')
+        return jnp.array([RegularGridInterpolator((wl_native,),r)(wl) for r in jnp.rollaxis(result,1)])
+        
 
-    def __init__(self, wl: u.Quantity, spectra: list, *params):
-        params = params + (wl.to_value(config.wl_unit),)
-        spectra = np.array(spectra)
-        self._evaluate = jit(RegularGridInterpolator(params, spectra))
-
-    def evaluate(self, wl: jnp.ndarray, *args)->jnp.ndarray:
+    def evaluate(
+            self,
+            params: Tuple[jnp.ndarray],
+            wl:jnp.ndarray = None
+        )->jnp.ndarray:
         """
         Evaluate the grid. `args` has the same order as `params` in the `__init__` method.
 
@@ -65,9 +124,18 @@ class GridSpectra:
             The flux of the grid at the evaluated points.
 
         """
-        X = jnp.array([jnp.ones_like(wl)*arg for arg in args] +
-                      [wl]).T
-        return self._evaluate(X)
+        if wl is None:
+            wl = self._wl
+        if len(params) != len(self._params):
+            raise ValueError(f'params must have {len(self._params)} values, but has {len(params)}.')
+        for param in params:
+            if param.ndim != 1:
+                raise ValueError(f'params must be 1D arrays, but has shape {param.shape}.')
+        param_lens = jnp.array([param.shape[0] for param in params])
+        if not jnp.all(param_lens == param_lens[0]):
+            raise ValueError(f'params must have equal lengths, but have lengths {param_lens}.')
+        
+        return self._evaluate(self._interp,params,self._wl, wl)
 
     @classmethod
     def from_vspec(
@@ -105,4 +173,6 @@ class GridSpectra:
             else:
                 if not np.all(isclose(wl, wave, 1e-6*u.um)):
                     raise ValueError('Wavelength values are different!')
-        return cls(wl, np.array(specs), np.array([teff.to_value(config.teff_unit) for teff in teffs]))
+        params = OrderedDict([('teff', jnp.array([teff.to_value(config.teff_unit) for teff in teffs]))])
+        specs = jnp.array(specs)
+        return cls(wl[:-1], params, specs)

--- a/GridPolator/grid.py
+++ b/GridPolator/grid.py
@@ -1,16 +1,21 @@
+"""
+GridPolator.grid
+================
+
+The ``GridSpectra`` class stores,
+recalls, and interpolates a grid of spectra.
+"""
+from typing import Tuple, List
 from collections import OrderedDict
 import numpy as np
 from jax import numpy as jnp
-from jax import jit
 from jax.scipy.interpolate import RegularGridInterpolator
 from astropy import units as u
 from tqdm.auto import tqdm
-from typing import Tuple, List, OrderedDict
 
 from GridPolator.builtins.phoenix_vspec import read_phoenix
 from GridPolator.astropy_units import isclose
 from GridPolator import config
-from GridPolator.binning import bin_spectra
 
 
 class GridSpectra:
@@ -19,95 +24,98 @@ class GridSpectra:
 
     Parameters
     ----------
-    wl : astropy.units.Quantity
-        The wavelength axis of the spectra.
-    spectra : list of numpy.ndarray
-        The flux values to place in the grid.
-    params : tuple of numpy.ndarray
-        The other axes of the grid.
+    native_wl : jax.numpy.ndarray
+        The native wavelength axis of the grid.
+    params : OrderedDict
+        The other axes of the grid. The order is the same
+        as the order of axes in `spectra`.
+    spectra : jax.numpy.ndarray
+        The flux values to place in the grid. The last dimension
+        should be wavelength.
 
     Examples
     --------
-    >>> spectra = [spec1,spec2,spec3]
-    >>> params = (3000,3100,3200)
-    >>> GridSpectra(wl,spectra,params)
+    >>> spectra = jnp.array([spec1,spec2,spec3]
+    >>> params = {'teff': jnp.array([3000,3100,3200])}
+    >>> wl = jnp.linspace(0,10,20)
+    >>> GridSpectra(wl,params,spectra)
 
-    >>> spectra = [
+    >>> spectra = jnp.array([
             [spec11,spec12],
             [spec21,spec22],
             [spec31,spec32]
-        ]
-    >>> params = [
-            (3000,3100,3200), # teff
-            (-1,1)          # metalicity
-        ]
-    >>> GridSpectra(wl,spectra,*params)
+        ])
+    >>> params = {
+            'teff': jnp.array([3000,3100,3200]),
+            'metalicity': jnp.array([-1,1])
+        }
+    >>> GridSpectra(wl,params,spectra)
 
     """
-    
+
     def __init__(
         self,
         native_wl: jnp.ndarray,
-        params: OrderedDict[str,jnp.ndarray],
+        params: OrderedDict[str, jnp.ndarray],
         spectra: jnp.ndarray
     ):
         """
         Initialize a grid object.
-        
-        Parameters
-        ----------
-        native_wl : jax.numpy.ndarray
-            The native wavelength axis of the grid.
-        params : OrderedDict
-            The other axes of the grid. The order is the same
-            as the order of axes in `spectra`.
-        spectra : jax.numpy.ndarray
-            The flux values to place in the grid. The last dimension
-            should be wavelength.
+
+
         """
         for param_name, param_val in params.items():
-            if not isinstance(param_name,str):
-                raise TypeError(f'param_name must be a string, but has type {type(param_name)}.')
-            if not isinstance(param_val,jnp.ndarray):
-                raise TypeError(f'param_val must be a jax.numpy.ndarray, but has type {type(param_val)}.')
+            if not isinstance(param_name, str):
+                raise TypeError(
+                    f'param_name must be a string, but has type {type(param_name)}.')
+            if not isinstance(param_val, jnp.ndarray):
+                raise TypeError(
+                    f'param_val must be a jax.numpy.ndarray, but has type {type(param_val)}.')
             if param_val.ndim != 1:
-                raise ValueError(f'param_val must be 1D, but has shape {param_val.shape}.')
+                raise ValueError(
+                    f'param_val must be 1D, but has shape {param_val.shape}.')
         n_params = len(params)
         if spectra.ndim != n_params + 1:
-            raise ValueError(f'spectra must have {n_params} dimensions, but has {spectra.ndim}.')
+            raise ValueError(
+                f'spectra must have {n_params} dimensions, but has {spectra.ndim}.')
         for i, (param_name, param_val) in enumerate(params.items()):
             if spectra.shape[i] != len(param_val):
-                raise ValueError(f'spectra must have {len(param_val)} values in the {i}th dimension, but has {spectra.shape[i]}.')
+                raise ValueError(
+                    f'spectra must have {len(param_val)} values in the {i}th dimension, but has {spectra.shape[i]}.')
         if native_wl.ndim != 1:
-            raise ValueError(f'native_wl must be a 1D array, but has shape {native_wl.shape}.')
+            raise ValueError(
+                f'native_wl must be a 1D array, but has shape {native_wl.shape}.')
         wl_len = native_wl.shape[0]
         if spectra.shape[-1] != wl_len:
-            raise ValueError(f'spectra must have {native_wl.shape[0]} values in the last dimension, but has {spectra.shape[-1]}.')
-        
+            raise ValueError(
+                f'spectra must have {native_wl.shape[0]} values in the last dimension, but has {spectra.shape[-1]}.')
+
         param_tup = tuple(params.values())
-        interp = [RegularGridInterpolator(param_tup,spectra[...,i]) for i in range(wl_len)]
-        
+        interp = [RegularGridInterpolator(
+            param_tup, spectra[..., i]) for i in range(wl_len)]
+
         self._wl = native_wl
         self._interp = interp
         self._params = params
+
     @staticmethod
     def _evaluate(
         interp: List[RegularGridInterpolator],
         params: Tuple[jnp.ndarray],
         wl_native: jnp.ndarray,
-        wl:jnp.ndarray
+        wl: jnp.ndarray
     ):
         result = jnp.array([_interp(params) for _interp in interp])
         if result.ndim != 2:
-            raise ValueError(f'result must have 2 dimensions, but has {result.ndim}.')
-        return jnp.array([RegularGridInterpolator((wl_native,),r)(wl) for r in jnp.rollaxis(result,1)])
-        
+            raise ValueError(
+                f'result must have 2 dimensions, but has {result.ndim}.')
+        return jnp.array([RegularGridInterpolator((wl_native,), r)(wl) for r in jnp.rollaxis(result, 1)])
 
     def evaluate(
-            self,
-            params: Tuple[jnp.ndarray],
-            wl:jnp.ndarray = None
-        )->jnp.ndarray:
+        self,
+        params: Tuple[jnp.ndarray],
+        wl: jnp.ndarray = None
+    ) -> jnp.ndarray:
         """
         Evaluate the grid. `args` has the same order as `params` in the `__init__` method.
 
@@ -127,15 +135,18 @@ class GridSpectra:
         if wl is None:
             wl = self._wl
         if len(params) != len(self._params):
-            raise ValueError(f'params must have {len(self._params)} values, but has {len(params)}.')
+            raise ValueError(
+                f'params must have {len(self._params)} values, but has {len(params)}.')
         for param in params:
             if param.ndim != 1:
-                raise ValueError(f'params must be 1D arrays, but has shape {param.shape}.')
+                raise ValueError(
+                    f'params must be 1D arrays, but has shape {param.shape}.')
         param_lens = jnp.array([param.shape[0] for param in params])
         if not jnp.all(param_lens == param_lens[0]):
-            raise ValueError(f'params must have equal lengths, but have lengths {param_lens}.')
-        
-        return self._evaluate(self._interp,params,self._wl, wl)
+            raise ValueError(
+                f'params must have equal lengths, but have lengths {param_lens}.')
+
+        return self._evaluate(self._interp, params, self._wl, wl)
 
     @classmethod
     def from_vspec(
@@ -173,6 +184,7 @@ class GridSpectra:
             else:
                 if not np.all(isclose(wl, wave, 1e-6*u.um)):
                     raise ValueError('Wavelength values are different!')
-        params = OrderedDict([('teff', jnp.array([teff.to_value(config.teff_unit) for teff in teffs]))])
+        params = OrderedDict(
+            [('teff', jnp.array([teff.to_value(config.teff_unit) for teff in teffs]))])
         specs = jnp.array(specs)
         return cls(wl[:-1], params, specs)

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -17,5 +17,11 @@ or in development mode:
 .. code-block:: shell
 
     git clone https://github.com/VSPEC-collab/GridPolator.git
-    cd VSPEC
+    cd GridPolator
     pip install -e .
+
+or get a specific release (e.g. `v0.1.0`):
+
+.. code-block:: shell
+
+    pip install git+https://github.com/VSPEC-collab/GridPolator.git@v0.1.0

--- a/examples/plot_use_vspec_grid.py
+++ b/examples/plot_use_vspec_grid.py
@@ -6,6 +6,7 @@ This example shows how to use the VSPEC grid.
 """
 from astropy import units as u
 import numpy as np
+from jax import numpy as jnp
 import matplotlib.pyplot as plt
 
 from GridPolator import GridSpectra
@@ -36,9 +37,12 @@ spec = GridSpectra.from_vspec(
 new_wl:u.Quantity = np.linspace(2,5,40) * u.um
 teff = 3050 * u.K
 
-flux = spec.evaluate(new_wl.to_value(config.wl_unit), teff.to_value(config.teff_unit))
+new_wl = jnp.array(new_wl.to_value(config.wl_unit))
+teff = jnp.array([teff.to_value(config.teff_unit)])
+
+flux = spec.evaluate((teff,), new_wl)[0]
 
 plt.plot(new_wl, flux)
-plt.xlabel(f'Wavelength ({new_wl.unit:latex})')
+plt.xlabel(f'Wavelength ({config.wl_unit:latex})')
 _=plt.ylabel(f'Flux ({config.flux_unit:latex})')
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -1,0 +1,140 @@
+"""
+Tests for the `Grid` class
+"""
+
+from collections import OrderedDict
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from astropy import units as u
+
+from GridPolator import GridSpectra
+
+
+def test_grid_1d():
+    wl = jnp.linspace(0,10,20)
+    params = OrderedDict(
+        [
+            ('teff', jnp.array([3000, 3100, 3200])),
+        ]
+    )
+    spectra = jnp.asarray(
+        [jnp.ones_like(wl)*t for t in params['teff']],
+    )
+    grid = GridSpectra(wl, params, spectra)
+    first_point = grid._interp[0]
+    test_teff = jnp.array([3050])
+    assert first_point(test_teff) == test_teff
+    assert first_point((test_teff,)) == test_teff
+    
+def test_grid_1d_bad_init():
+    """
+    Test that the GridSpectra class raises an error if the
+    parameters are bad.
+    """
+    wl = jnp.linspace(0,10,20)
+    params = OrderedDict(
+        [
+            ('teff', jnp.array([3000, 3100, 3200])),
+        ]
+    )
+    spectra = jnp.asarray(
+        [jnp.ones_like(wl)*t for t in params['teff']],
+    )
+    
+    with pytest.raises(TypeError):
+        GridSpectra(wl, OrderedDict([(0,jnp.array([3000, 3100, 3200]))]), spectra)
+    with pytest.raises(TypeError):
+        GridSpectra(wl, OrderedDict([('teff',np.array([3000, 3100, 3200]))]), spectra)
+    with pytest.raises(ValueError):
+        GridSpectra(wl, OrderedDict([('teff',jnp.array([[3000, 3100, 3200]]))]), spectra)
+    with pytest.raises(ValueError):
+        GridSpectra(wl,params,jnp.array([
+            [jnp.ones_like(wl) for t in params['teff']],
+            [jnp.ones_like(wl) for t in params['teff']],
+        ]))
+    with pytest.raises(ValueError):
+        GridSpectra(jnp.array([wl,wl]),params,spectra)
+    with pytest.raises(ValueError):
+        GridSpectra(wl,params,jnp.array(
+            [jnp.ones_like(wl) for i in range(5)],
+            
+        ))
+    
+    
+def test_grid_2d():
+    wl = jnp.linspace(0,10,20)
+    params = OrderedDict(
+        [
+            ('teff', jnp.array([3000, 3100, 3200])),
+            ('metallicity', jnp.array([-1, 0, 1])),
+        ]
+    )
+    spectra = jnp.asarray(
+        [
+            [jnp.ones_like(wl)*t*m for m in params['metallicity']] for t in params['teff']
+        ]
+    )
+    grid = GridSpectra(wl, params, spectra)
+    first_point = grid._interp[0]
+    test_teff = jnp.array([3050,3000,3100,3150])
+    test_metallicity = jnp.array([0,0.5,1,0.2])
+    assert jnp.all(first_point((test_teff, test_metallicity)) == test_teff*test_metallicity)
+
+def test_grid_1d_eval():
+    wl = jnp.linspace(0,10,20)
+    params = OrderedDict(
+        [
+            ('teff', jnp.array([3000, 3100, 3200])),
+        ]
+    )
+    spectra = jnp.asarray(
+        [jnp.ones_like(wl)*t for t in params['teff']],
+    )
+    grid = GridSpectra(wl, params, spectra)
+    test_teff = jnp.array([3050,3100])
+    result = grid.evaluate((test_teff,))
+    for i, t in enumerate(test_teff):
+        assert jnp.all(result[i] == t)
+
+def test_grid_eval_2d():
+    wl = jnp.linspace(0,10,20)
+    params = OrderedDict(
+        [
+            ('teff', jnp.array([3000, 3100, 3200])),
+            ('metallicity', jnp.array([-1, 0, 1])),
+        ]
+    )
+    spectra = jnp.asarray(
+        [
+            [jnp.ones_like(wl)*t*m for m in params['metallicity']] for t in params['teff']
+        ]
+    )
+    grid = GridSpectra(wl, params, spectra)
+    test_teff = jnp.array([3050,3100])
+    test_metalicity = jnp.array([0.5,1])
+    result = grid.evaluate((test_teff, test_metalicity))
+    for i, (t,m) in enumerate(zip(test_teff,test_metalicity)):
+        assert jnp.all(result[i] == t*m)
+
+def test_vspec():
+    wl1 = 1*u.um
+    wl2 = 10*u.um
+    resolving_power = 50
+    teffs = [3000,3100,3200] * u.K
+    
+    grid = GridSpectra.from_vspec(
+        w1=wl1,
+        w2=wl2,
+        resolving_power=resolving_power,
+        teffs = teffs
+    )
+    new_wl = jnp.linspace(2,8,100)
+    flux = grid.evaluate((jnp.array([3050]),), new_wl)
+    assert isinstance(flux, jnp.ndarray)
+    assert flux.shape == (1,100)
+    
+    
+if __name__ == '__main__':
+    pytest.main(args=[__file__])
+        

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -12,7 +12,11 @@ from GridPolator import GridSpectra
 
 
 def test_grid_1d():
-    wl = jnp.linspace(0,10,20)
+    """
+    Test that the GridSpectra class can be initialized
+    with 1D arrays.
+    """
+    wl = jnp.linspace(0, 10, 20)
     params = OrderedDict(
         [
             ('teff', jnp.array([3000, 3100, 3200])),
@@ -22,17 +26,19 @@ def test_grid_1d():
         [jnp.ones_like(wl)*t for t in params['teff']],
     )
     grid = GridSpectra(wl, params, spectra)
+    # pylint: disable-next=protected-access
     first_point = grid._interp[0]
     test_teff = jnp.array([3050])
     assert first_point(test_teff) == test_teff
     assert first_point((test_teff,)) == test_teff
-    
+
+
 def test_grid_1d_bad_init():
     """
     Test that the GridSpectra class raises an error if the
     parameters are bad.
     """
-    wl = jnp.linspace(0,10,20)
+    wl = jnp.linspace(0, 10, 20)
     params = OrderedDict(
         [
             ('teff', jnp.array([3000, 3100, 3200])),
@@ -41,29 +47,36 @@ def test_grid_1d_bad_init():
     spectra = jnp.asarray(
         [jnp.ones_like(wl)*t for t in params['teff']],
     )
-    
+
     with pytest.raises(TypeError):
-        GridSpectra(wl, OrderedDict([(0,jnp.array([3000, 3100, 3200]))]), spectra)
+        GridSpectra(wl, OrderedDict(
+            [(0, jnp.array([3000, 3100, 3200]))]), spectra)
     with pytest.raises(TypeError):
-        GridSpectra(wl, OrderedDict([('teff',np.array([3000, 3100, 3200]))]), spectra)
+        GridSpectra(wl, OrderedDict(
+            [('teff', np.array([3000, 3100, 3200]))]), spectra)
     with pytest.raises(ValueError):
-        GridSpectra(wl, OrderedDict([('teff',jnp.array([[3000, 3100, 3200]]))]), spectra)
+        GridSpectra(wl, OrderedDict(
+            [('teff', jnp.array([[3000, 3100, 3200]]))]), spectra)
     with pytest.raises(ValueError):
-        GridSpectra(wl,params,jnp.array([
+        GridSpectra(wl, params, jnp.array([
             [jnp.ones_like(wl) for t in params['teff']],
             [jnp.ones_like(wl) for t in params['teff']],
         ]))
     with pytest.raises(ValueError):
-        GridSpectra(jnp.array([wl,wl]),params,spectra)
+        GridSpectra(jnp.array([wl, wl]), params, spectra)
     with pytest.raises(ValueError):
-        GridSpectra(wl,params,jnp.array(
+        GridSpectra(wl, params, jnp.array(
             [jnp.ones_like(wl) for i in range(5)],
-            
+
         ))
-    
-    
+
+
 def test_grid_2d():
-    wl = jnp.linspace(0,10,20)
+    """
+    Test that the GridSpectra class can be initialized
+    with 2D arrays.
+    """
+    wl = jnp.linspace(0, 10, 20)
     params = OrderedDict(
         [
             ('teff', jnp.array([3000, 3100, 3200])),
@@ -76,13 +89,20 @@ def test_grid_2d():
         ]
     )
     grid = GridSpectra(wl, params, spectra)
+    # pylint: disable-next=protected-access
     first_point = grid._interp[0]
-    test_teff = jnp.array([3050,3000,3100,3150])
-    test_metallicity = jnp.array([0,0.5,1,0.2])
-    assert jnp.all(first_point((test_teff, test_metallicity)) == test_teff*test_metallicity)
+    test_teff = jnp.array([3050, 3000, 3100, 3150])
+    test_metallicity = jnp.array([0, 0.5, 1, 0.2])
+    assert jnp.all(first_point((test_teff, test_metallicity))
+                   == test_teff*test_metallicity)
+
 
 def test_grid_1d_eval():
-    wl = jnp.linspace(0,10,20)
+    """
+    Test that the GridSpectra class can be evaluated
+    when created with 1D arrays.
+    """
+    wl = jnp.linspace(0, 10, 20)
     params = OrderedDict(
         [
             ('teff', jnp.array([3000, 3100, 3200])),
@@ -92,13 +112,18 @@ def test_grid_1d_eval():
         [jnp.ones_like(wl)*t for t in params['teff']],
     )
     grid = GridSpectra(wl, params, spectra)
-    test_teff = jnp.array([3050,3100])
+    test_teff = jnp.array([3050, 3100])
     result = grid.evaluate((test_teff,))
     for i, t in enumerate(test_teff):
         assert jnp.all(result[i] == t)
 
+
 def test_grid_eval_2d():
-    wl = jnp.linspace(0,10,20)
+    """
+    Test that the GridSpectra class can be evaluated
+    when created with 2D arrays.
+    """
+    wl = jnp.linspace(0, 10, 20)
     params = OrderedDict(
         [
             ('teff', jnp.array([3000, 3100, 3200])),
@@ -111,30 +136,34 @@ def test_grid_eval_2d():
         ]
     )
     grid = GridSpectra(wl, params, spectra)
-    test_teff = jnp.array([3050,3100])
-    test_metalicity = jnp.array([0.5,1])
+    test_teff = jnp.array([3050, 3100])
+    test_metalicity = jnp.array([0.5, 1])
     result = grid.evaluate((test_teff, test_metalicity))
-    for i, (t,m) in enumerate(zip(test_teff,test_metalicity)):
+    for i, (t, m) in enumerate(zip(test_teff, test_metalicity)):
         assert jnp.all(result[i] == t*m)
 
+
 def test_vspec():
+    """
+    Test that the grid can be initialized from
+    the vspec grid.
+    """
     wl1 = 1*u.um
     wl2 = 10*u.um
     resolving_power = 50
-    teffs = [3000,3100,3200] * u.K
-    
+    teffs = [3000, 3100, 3200] * u.K
+
     grid = GridSpectra.from_vspec(
         w1=wl1,
         w2=wl2,
         resolving_power=resolving_power,
-        teffs = teffs
+        teffs=teffs
     )
-    new_wl = jnp.linspace(2,8,100)
+    new_wl = jnp.linspace(2, 8, 100)
     flux = grid.evaluate((jnp.array([3050]),), new_wl)
     assert isinstance(flux, jnp.ndarray)
-    assert flux.shape == (1,100)
-    
-    
+    assert flux.shape == (1, 100)
+
+
 if __name__ == '__main__':
     pytest.main(args=[__file__])
-        


### PR DESCRIPTION
- Treat each wavelength point as orthogonal.
- New simplified API for initializing `GridSpectra` objects.
- Update examples.
- Add instructions in docs for installing from a release tag.