### PR TITLE
Faster grid evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "GridPolator"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ndarray",
  "numpy",

--- a/test/test_phoenix_vspec.py
+++ b/test/test_phoenix_vspec.py
@@ -25,7 +25,6 @@ def test_get_url():
     with pytest.raises(ValueError):
         phoenix_vspec.get_url(0)
 
-# @pytest.mark.skip()
 def test_download():
     """
     Test the download function.
@@ -87,3 +86,6 @@ def test_read_phoenix():
     assert wl.unit == config.wl_unit
     assert fl.unit == config.flux_unit
     # assert len(wl) == len(fl)
+
+if __name__ == '__main__':
+    pytest.main(args=[__file__])


### PR DESCRIPTION
- JIT compile each grid's `_evaluate` method
- First eval is slow due to compilation, but the rest are much faster.
- Add progress bar to VSPEC grid downloads